### PR TITLE
Remove flex 1 to fix breaking change in RN@0.36

### DIFF
--- a/Carousel.js
+++ b/Carousel.js
@@ -136,7 +136,7 @@ var Carousel = React.createClass({
 
   render() {
     return (
-      <View style={{ flex: 1 }}>
+      <View>
         <CarouselPager
           ref="pager"
           width={this.getWidth()}


### PR DESCRIPTION
A breaking change was introduced in React Native 0.36 as detailed here https://github.com/facebook/react-native/wiki/Breaking-Changes#fix-unconstraint-sizing-in-main-axis-0a9b6b---emilsjolander
This commit is to fix the layout of the carousel so that it doesn't collapse to height of 0.